### PR TITLE
Partial rebuild of index

### DIFF
--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -178,13 +178,16 @@ where
 
     /// iterates over all configured ACLs
     pub fn list<'a>(&'a mut self) -> Result<impl Iterator<Item = Result<(Key, ACL)>> + 'a> {
-        Ok(self.inner.keys()?.filter_map(move |k| match self.get(k) {
-            Ok(acl) => match acl {
-                Some(acl) => Some(Ok((k, acl))),
-                None => None,
-            },
-            Err(err) => Some(Err(err)),
-        }))
+        Ok(self
+            .inner
+            .keys()?
+            .filter_map(move |r| match self.get(r.key) {
+                Ok(acl) => match acl {
+                    Some(acl) => Some(Ok((r.key, acl))),
+                    None => None,
+                },
+                Err(err) => Some(Err(err)),
+            }))
     }
 }
 

--- a/src/database/index.rs
+++ b/src/database/index.rs
@@ -240,10 +240,10 @@ where
     /// from.
     pub async fn rebuild(&mut self) -> Result<()> {
         for k in self.storage.keys()? {
-            let data = match self.storage.get(k)? {
+            let data = match self.storage.get(k.key)? {
                 Some(data) => data,
                 None => {
-                    warn!("metadata with key '{}' not found", k);
+                    warn!("metadata with key '{}' not found", k.key);
                     continue;
                 }
             };

--- a/src/database/index.rs
+++ b/src/database/index.rs
@@ -238,7 +238,57 @@ where
     /// rebuild index by scanning the storage database for entries,
     /// and calling set on the index store. Optionally start scanning from
     /// from.
-    pub async fn rebuild(&mut self) -> Result<()> {
+    pub async fn rebuild(&mut self, from: Option<u32>) -> Result<()> {
+        match from {
+            None => self.rebuild_all().await,
+            Some(ts) => self.rebuild_from(ts).await,
+        }
+    }
+
+    async fn rebuild_from(&mut self, from: u32) -> Result<()> {
+        let mut start = None;
+        // we try to find the first KEY that is created after this timestamp
+        // we iterate backwards, check each key insertion time, until we hit a key
+        // that was created before this time. Once we have found the one, we use the
+        // first key after this one, and continue scanning from there.
+        for r in self.storage.rev()? {
+            let ts = match r.timestamp {
+                Some(ts) => ts,
+                None => {
+                    bail!("rebuild from storage is not supported for this storage implementation")
+                }
+            };
+
+            if ts < from {
+                break;
+            }
+
+            start = Some(r.key);
+        }
+
+        if start.is_none() {
+            return Ok(());
+        }
+
+        let mut key = start.unwrap();
+
+        loop {
+            let data = match self.storage.get(key)? {
+                Some(data) => data,
+                None => {
+                    break; // we hit the end
+                }
+            };
+
+            let obj = serde_json::from_slice::<ZdbMetaDe>(&data)?;
+            self.inner.set(obj.key, Meta::from(obj.tags)).await?;
+            key += 1;
+        }
+
+        Ok(())
+    }
+
+    async fn rebuild_all(&mut self) -> Result<()> {
         for k in self.storage.keys()? {
             let data = match self.storage.get(k.key)? {
                 Some(data) => data,

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ async fn entry() -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(_) = matches.subcommand_matches("rebuild") {
         let mut index = index;
-        index.rebuild().await?;
+        index.rebuild(None).await?;
         return Ok(());
     }
 

--- a/src/storage/encrypted.rs
+++ b/src/storage/encrypted.rs
@@ -3,7 +3,7 @@ use aes_gcm::{aead, Aes256Gcm};
 use rand::prelude::*;
 use rand::rngs::OsRng;
 
-use super::{Error as StorageError, Key, Storage};
+use super::{Error as StorageError, Key, Record, Storage};
 
 const ENCRYPTION_KEY_SIZE: usize = 32;
 const NONCE_SIZE: usize = 12;
@@ -64,8 +64,12 @@ where
         Ok(Some(plaintext))
     }
 
-    fn keys(&mut self) -> Result<Box<dyn Iterator<Item = Key> + Send>, StorageError> {
+    fn keys(&mut self) -> Result<Box<dyn Iterator<Item = Record> + Send>, StorageError> {
         self.backend.keys()
+    }
+
+    fn rev(&mut self) -> Result<Box<dyn Iterator<Item = Record> + Send>, StorageError> {
+        self.backend.rev()
     }
 }
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -117,7 +117,7 @@ mod tests {
         assert_eq!(None, storage.get(17).unwrap());
 
         // key equality
-        let mut keys = storage.keys().unwrap().collect::<Vec<_>>();
+        let mut keys = storage.keys().unwrap().map(|r| r.key).collect::<Vec<_>>();
         keys.sort();
         assert_eq!(keys, vec![key1, key2, key3]);
     }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use super::{Error, Key, Storage};
+use super::{Error, Key, Record, Storage};
 
 #[derive(Debug, Clone)]
 pub struct MemoryStorage {
@@ -50,7 +50,7 @@ impl Storage for MemoryStorage {
         }
     }
 
-    fn keys(&mut self) -> Result<Box<dyn Iterator<Item = Key> + Send>, Error> {
+    fn keys(&mut self) -> Result<Box<dyn Iterator<Item = Record> + Send>, Error> {
         let handle = self.internal.read().unwrap();
         Ok(Box::new(
             handle
@@ -58,7 +58,30 @@ impl Storage for MemoryStorage {
                 .keys()
                 .copied()
                 .collect::<Vec<Key>>()
-                .into_iter(),
+                .into_iter()
+                .map(|v| Record {
+                    key: v,
+                    timestamp: None,
+                    size: None,
+                }),
+        ))
+    }
+
+    fn rev(&mut self) -> Result<Box<dyn Iterator<Item = Record> + Send>, Error> {
+        let handle = self.internal.read().unwrap();
+        Ok(Box::new(
+            handle
+                .backend
+                .keys()
+                .copied()
+                .collect::<Vec<Key>>()
+                .into_iter()
+                .map(|v| Record {
+                    key: v,
+                    timestamp: None,
+                    size: None,
+                })
+                .rev(),
         ))
     }
 }

--- a/src/storage/zdb/external.rs
+++ b/src/storage/zdb/external.rs
@@ -194,8 +194,8 @@ impl Iterator for CollectionKeys {
             let key = read_le_key(&rec.0);
             return Some(Record {
                 key: key,
-                timestamp: Some(rec.1),
-                size: Some(rec.2),
+                size: Some(rec.1),
+                timestamp: Some(rec.2),
             });
         }
         // No more keys in buffer, fetch a new buffer from the remote
@@ -225,8 +225,8 @@ impl Iterator for CollectionKeys {
         let key = read_le_key(&rec.0);
         Some(Record {
             key: key,
-            timestamp: Some(rec.1),
-            size: Some(rec.2),
+            size: Some(rec.1),
+            timestamp: Some(rec.2),
         })
     }
 }


### PR DESCRIPTION
Accept extra argument `--from` for the rebuild subcommand that only rebuild the index from that timestamp to the end. This is done by scanning the zdb metadata namespace backwards until we find the first entry, then rerun the metadata transactions from that point in time to the end.