### PR TITLE
Rest find mode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -50,7 +50,11 @@ The find interface to find object(s) using tags. It accepts an arbitrary query s
 
 > **Note**: due to a bug in the server router, the query params must always be provided, to do an empty query (find everything) use `?_=` as query string. (for example `GET http:://localhost:50061/db/mycollection/?_=`)
 
+#### Different find modes
+You can select the `find` mode, using an optional header `x-find-mode`. This only supports 2 modes at the moment
+- `find` this is the default mode if the header is not set.
 Returns a stream of json object (not a list). The object ONLY contains the id and the metadata (tags) but not the content, if you need to retrieve the content a separate GET call must be done.
+- `list` this has to be selected by setting the `x-find-mode: list` header. In this mode the returned objects are just the ids of your objects that are matching your query. No tags are returned
 
 ## Acl endpoints
 Acl are use to configure `access control list` groups. A single ACL object is a group of user ids, associated with a permission string. Then the same object can be assigned to multiple objects at the same time.


### PR DESCRIPTION
Support different find modes:
- Find, which returns the full object informations (id + tags) but no content
- List, which returns only the object ID

Both find modes returns stream of "json" objects, not a list